### PR TITLE
STEP_8: added ability to find new articles and send notifications about new of them. Test would be provided later.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.7.0-SNAPSHOT
+
+*   JRTB-4: added ability to send notifications about new articles
+*   JRTB-8: added ability to set inactive telegram user
+*   JRTB-9: added ability to set active user and/or start using it.
+
 ## 0.6.0-SNAPSHOT
 
 *   JRTB-7: added the ability to delete group subscription.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.javarushcommunity</groupId>
 	<artifactId>javarush-telegrambot</artifactId>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.7.0-SNAPSHOT</version>
 	<name>Javarush TelegramBot</name>
 	<description>Telegram bot for Javarush from community to community</description>
 	<properties>

--- a/src/main/java/com/github/javarushcommunity/jrtb/JavarushTelegramBotApplication.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/JavarushTelegramBotApplication.java
@@ -3,7 +3,10 @@ package com.github.javarushcommunity.jrtb;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableScheduling
 @SpringBootApplication
 @PropertySource("classpath:application-dev.properties")
 public class JavarushTelegramBotApplication {

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushPostClient.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushPostClient.java
@@ -1,0 +1,20 @@
+package com.github.javarushcommunity.jrtb.javarushclient;
+
+import com.github.javarushcommunity.jrtb.javarushclient.dto.PostInfo;
+
+import java.util.List;
+
+/**
+ * Client for Javarush Open API corresponds to Posts.
+ */
+public interface JavaRushPostClient {
+
+    /**
+     * Find new posts since lastPostId in provided group.
+     *
+     * @param groupId provided group ID.
+     * @param lastPostId provided last post ID.
+     * @return the collection of the new {@link PostInfo}.
+     */
+    List<PostInfo> findNewPosts(Integer groupId, Integer lastPostId);
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushPostClientImpl.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushPostClientImpl.java
@@ -1,0 +1,38 @@
+package com.github.javarushcommunity.jrtb.javarushclient;
+
+import com.github.javarushcommunity.jrtb.javarushclient.dto.PostInfo;
+import kong.unirest.GenericType;
+import kong.unirest.Unirest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class JavaRushPostClientImpl implements JavaRushPostClient {
+
+    private final String javarushApiPostPath;
+
+    public JavaRushPostClientImpl(@Value("${javarush.api.path}") String javarushApi) {
+        this.javarushApiPostPath = javarushApi + "/posts";
+    }
+
+    @Override
+    public List<PostInfo> findNewPosts(Integer groupId, Integer lastPostId) {
+        List<PostInfo> lastPostsByGroup = Unirest.get(javarushApiPostPath)
+                .queryString("order", "NEW")
+                .queryString("groupKid", groupId)
+                .queryString("limit", 15)
+                .asObject(new GenericType<List<PostInfo>>() {
+                }).getBody();
+        List<PostInfo> newPosts = new ArrayList<>();
+        for (PostInfo post : lastPostsByGroup) {
+            if (lastPostId.equals(post.getId())) {
+                return newPosts;
+            }
+            newPosts.add(post);
+        }
+        return newPosts;
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/AuthorInfo.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/AuthorInfo.java
@@ -1,0 +1,30 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+import lombok.Data;
+
+/**
+ * DTO, which represents base user information.
+ */
+@Data
+public class AuthorInfo {
+    private String city;
+    private String companyUrl;
+    private String country;
+    private String csdnUrl;
+    private String description;
+    private String displayName;
+    private String externalEmail;
+    private String facebookUrl;
+    private String githubUrl;
+    private String instagramUrl;
+    private String job;
+    private String key;
+    private Integer level;
+    private String linkedinUrl;
+    private String mediumUrl;
+    private String pictureUrl;
+    private String position;
+    private String stackoverflowUrl;
+    private String twitterUrl;
+    private Integer userId;
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/Language.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/Language.java
@@ -1,0 +1,8 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+/**
+ * DTO, which represents languages.
+ */
+public enum Language {
+    UNKNOWN, ENGLISH, GERMAN, SPANISH, HINDI, FRENCH, PORTUGUESE, POLISH, BENGALI, PUNJABI, CHINESE, ITALIAN, INDONESIAN, MARATHI, TAMIL, TELUGU, JAPANESE, KOREAN, URDU, TAIWANESE, NETHERLANDS, RUSSIAN, UKRAINIAN
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/LikeStatus.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/LikeStatus.java
@@ -1,0 +1,9 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+/**
+ * DTO, which represents like's status.
+ */
+public enum LikeStatus {
+
+    UNKNOWN, LIKE, HOT, FOLLOW, FAVORITE, SOLUTION, HELPFUL, ARTICLE, OSCAR, DISLIKE, WRONG, SPAM, ABUSE, FOUL, TROLLING, OFFTOPIC, DUPLICATE, DIRTY, OUTDATED, BORING, UNCLEAR, HARD, EASY, FAKE, SHAM, AWFUL
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/LikesInfo.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/LikesInfo.java
@@ -1,0 +1,10 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+/**
+ * DTO, which represents like's information.
+ */
+public class LikesInfo {
+
+    private Integer count;
+    private LikeStatus status;
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/PostInfo.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/PostInfo.java
@@ -1,0 +1,32 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+import lombok.Data;
+
+/**
+ * DTO, which represents post information.
+ */
+@Data
+public class PostInfo {
+
+    private AuthorInfo authorInfo;
+    private Integer commentsCount;
+    private String content;
+    private Long createdTime;
+    private String description;
+    private GroupInfo groupInfo;
+    private Integer id;
+    private String key;
+    private Language language;
+    private LikesInfo likesInfo;
+    private GroupInfo originalGroupInfo;
+    private String pictureUrl;
+    private Double rating;
+    private Integer ratingCount;
+    private String title;
+    private PostType type;
+    private Long updatedTime;
+    private UserDiscussionInfo userDiscussionInfo;
+    private Integer views;
+    private VisibilityStatus visibilityStatus;
+
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/PostType.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/PostType.java
@@ -1,0 +1,8 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+/**
+ * DTO, which represents post types.
+ */
+public enum PostType {
+    UNKNOWN, USUAL, INNER_LINK, OUTER_LINK
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/VisibilityStatus.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/javarushclient/dto/VisibilityStatus.java
@@ -1,0 +1,8 @@
+package com.github.javarushcommunity.jrtb.javarushclient.dto;
+
+/**
+ * DTO, which represents visibility status.
+ */
+public enum VisibilityStatus {
+    UNKNOWN, RESTRICTED, PUBLIC, PROTECTED, PRIVATE, DISABLED, DELETED
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/job/FindNewArticlesJob.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/job/FindNewArticlesJob.java
@@ -1,0 +1,39 @@
+package com.github.javarushcommunity.jrtb.job;
+
+import com.github.javarushcommunity.jrtb.service.FindNewArticleService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * Job for finding new articles.
+ */
+@Slf4j
+@Component
+public class FindNewArticlesJob {
+
+    private final FindNewArticleService findNewArticleService;
+
+    @Autowired
+    public FindNewArticlesJob(FindNewArticleService findNewArticleService) {
+        this.findNewArticleService = findNewArticleService;
+    }
+
+    @Scheduled(fixedRateString = "${bot.recountNewArticleFixedRate}")
+    public void findNewArticles() {
+        LocalDateTime start = LocalDateTime.now();
+
+        log.info("Find new article job started.");
+
+        findNewArticleService.findNewArticles();
+
+        LocalDateTime end = LocalDateTime.now();
+
+        log.info("Find new articles job finished. Took seconds: {}",
+                end.toEpochSecond(ZoneOffset.UTC) - start.toEpochSecond(ZoneOffset.UTC));
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/service/FindNewArticleService.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/service/FindNewArticleService.java
@@ -1,0 +1,12 @@
+package com.github.javarushcommunity.jrtb.service;
+
+/**
+ * Service for finding new articles.
+ */
+public interface FindNewArticleService {
+
+    /**
+     * Find new articles and notify subscribers about it.
+     */
+    void findNewArticles();
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/service/FindNewArticleServiceImpl.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/service/FindNewArticleServiceImpl.java
@@ -1,0 +1,69 @@
+package com.github.javarushcommunity.jrtb.service;
+
+import com.github.javarushcommunity.jrtb.javarushclient.JavaRushPostClient;
+import com.github.javarushcommunity.jrtb.javarushclient.dto.PostInfo;
+import com.github.javarushcommunity.jrtb.repository.entity.GroupSub;
+import com.github.javarushcommunity.jrtb.repository.entity.TelegramUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FindNewArticleServiceImpl implements FindNewArticleService {
+
+    public static final String JAVARUSH_WEB_POST_FORMAT = "https://javarush.com/groups/posts/%s";
+
+    private final GroupSubService groupSubService;
+    private final JavaRushPostClient javaRushPostClient;
+    private final SendBotMessageService sendMessageService;
+
+    @Autowired
+    public FindNewArticleServiceImpl(GroupSubService groupSubService,
+                                     JavaRushPostClient javaRushPostClient,
+                                     SendBotMessageService sendMessageService) {
+        this.groupSubService = groupSubService;
+        this.javaRushPostClient = javaRushPostClient;
+        this.sendMessageService = sendMessageService;
+    }
+
+
+    @Override
+    public void findNewArticles() {
+        groupSubService.findAll().forEach(gSub -> {
+            List<PostInfo> newPosts = javaRushPostClient.findNewPosts(gSub.getId(), gSub.getLastArticleId());
+
+            setNewLastArticleId(gSub, newPosts);
+
+            notifySubscribersAboutNewArticles(gSub, newPosts);
+        });
+    }
+
+    private void notifySubscribersAboutNewArticles(GroupSub gSub, List<PostInfo> newPosts) {
+        Collections.reverse(newPosts);
+        List<String> messagesWithNewArticles = newPosts.stream()
+                .map(post -> String.format("✨Вышла новая статья <b>%s</b> в группе <b>%s</b>.✨\n\n" +
+                                "<b>Описание:</b> %s\n\n" +
+                                "<b>Ссылка:</b> %s\n",
+                        post.getTitle(), gSub.getTitle(), post.getDescription(), getPostUrl(post.getKey())))
+                .collect(Collectors.toList());
+
+        gSub.getUsers().stream()
+                .filter(TelegramUser::isActive)
+                .forEach(it -> sendMessageService.sendMessage(it.getChatId(), messagesWithNewArticles));
+    }
+
+    private void setNewLastArticleId(GroupSub gSub, List<PostInfo> newPosts) {
+        newPosts.stream().mapToInt(PostInfo::getId).max()
+                .ifPresent(id -> {
+                    gSub.setLastArticleId(id);
+                    groupSubService.save(gSub);
+                });
+    }
+
+    private String getPostUrl(String key) {
+        return String.format(JAVARUSH_WEB_POST_FORMAT, key);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageService.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageService.java
@@ -1,5 +1,7 @@
 package com.github.javarushcommunity.jrtb.service;
 
+import java.util.List;
+
 /**
  * Service for sending messages via telegram-bot.
  */
@@ -12,4 +14,12 @@ public interface SendBotMessageService {
      * @param message provided message to be sent.
      */
     void sendMessage(Long chatId, String message);
+
+    /**
+     * Send messages via telegram bot.
+     *
+     * @param chatId  provided chatId in which would be sent.
+     * @param message collection of provided messages to be sent.
+     */
+    void sendMessage(Long chatId, List<String> message);
 }

--- a/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageServiceImpl.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageServiceImpl.java
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+import java.util.List;
+
+import static org.springframework.util.CollectionUtils.isEmpty;
+
 /**
  * Implementation of {@link SendBotMessageService} interface.
  */
@@ -32,5 +36,12 @@ public class SendBotMessageServiceImpl implements SendBotMessageService {
             //todo add logging to the project.
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public void sendMessage(Long chatId, List<String> messages) {
+        if (isEmpty(messages)) return;
+
+        messages.forEach(m -> sendMessage(chatId, m));
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,3 +9,5 @@ bot.username=${BOT_USERNAME}
 bot.token=${BOT_TOKEN}
 
 javarush.api.path=https://javarush.com/api/1.0/rest
+
+bot.recountNewArticleFixedRate = 900000

--- a/src/test/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushGroupClientTest.java
+++ b/src/test/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushGroupClientTest.java
@@ -15,7 +15,9 @@ import static com.github.javarushcommunity.jrtb.javarushclient.dto.GroupInfoType
 @DisplayName("Integration-level testing for JavaRushGroupClientImplTest")
 class JavaRushGroupClientTest {
 
-    private final JavaRushGroupClient groupClient = new JavaRushGroupClientImpl("https://javarush.com/api/1.0/rest");
+    public static final String JAVARUSH_API_PATH = "https://javarush.ru/api/1.0/rest";
+
+    private final JavaRushGroupClient groupClient = new JavaRushGroupClientImpl(JAVARUSH_API_PATH);
 
     @Test
     public void shouldProperlyGetGroupsWithEmptyArgs() {

--- a/src/test/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushPostClientTest.java
+++ b/src/test/java/com/github/javarushcommunity/jrtb/javarushclient/JavaRushPostClientTest.java
@@ -1,0 +1,25 @@
+package com.github.javarushcommunity.jrtb.javarushclient;
+
+import com.github.javarushcommunity.jrtb.javarushclient.dto.PostInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.javarushcommunity.jrtb.javarushclient.JavaRushGroupClientTest.JAVARUSH_API_PATH;
+
+@DisplayName("Integration-level testing for JavaRushPostClient")
+class JavaRushPostClientTest {
+
+    private final JavaRushPostClient postClient = new JavaRushPostClientImpl(JAVARUSH_API_PATH);
+
+    @Test
+    public void shouldProperlyGetNew15Posts() {
+        //when
+        List<PostInfo> newPosts = postClient.findNewPosts(30, 2935);
+
+        //then
+        Assertions.assertEquals(15, newPosts.size());
+    }
+}


### PR DESCRIPTION
Added test for JavaRushPostClient.
Updated version to 0.7.0-SNAPSHOT.

# PR Details

## 0.7.0-SNAPSHOT

- JRTB-4: added ability to send notifications about new articles
- JRTB-8: added ability to set inactive telegram user
- JRTB-9: added ability to set active user and/or start using it.

## Related Issue

Working on next issues: [#25](https://github.com/neighborstan/javarush-telegrambot/issues/25) [#9](https://github.com/neighborstan/javarush-telegrambot/issues/9) [#10](https://github.com/neighborstan/javarush-telegrambot/issues/10)

## How Has This Been Tested

provided unit tests

## Types of changes

 

- [x] Docs change / refactoring / dependency upgrade
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)